### PR TITLE
feat: add custom_api_max_price_age parameter

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -103,7 +103,7 @@ jobs:
           git fetch --all -q
           git checkout -b $GITHUB_SHA
           coverage xml
-          diff-cover --compare-branch=origin/$GITHUB_BASE_REF coverage.xml
+          diff-cover --compare-branch=origin/$GITHUB_BASE_REF --fail-under=80 coverage.xml
 
       # Notify results to discord
       - uses: actions/setup-ruby@v1

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -103,7 +103,7 @@ jobs:
           git fetch --all -q
           git checkout -b $GITHUB_SHA
           coverage xml
-          diff-cover --compare-branch=origin/$GITHUB_BASE_REF --fail-under=80 coverage.xml
+          diff-cover --compare-branch=origin/$GITHUB_BASE_REF coverage.xml
 
       # Notify results to discord
       - uses: actions/setup-ruby@v1

--- a/hummingbot/data_feed/custom_api_data_feed.py
+++ b/hummingbot/data_feed/custom_api_data_feed.py
@@ -42,6 +42,22 @@ class CustomAPIDataFeed(NetworkBase):
         return "custom_api"
 
     @property
+    def api_url(self):
+        return self._api_url
+
+    @property
+    def update_interval(self):
+        return self._update_interval
+
+    @property
+    def max_price_age(self):
+        return self._max_price_age
+
+    @property
+    def last_updated_timestamp(self):
+        return self._last_updated_timestamp
+
+    @property
     def health_check_endpoint(self):
         return self._api_url
 

--- a/hummingbot/data_feed/custom_api_data_feed.py
+++ b/hummingbot/data_feed/custom_api_data_feed.py
@@ -21,8 +21,8 @@ class CustomAPIDataFeed(NetworkBase):
             cls.cadf_logger = logging.getLogger(__name__)
         return cls.cadf_logger
 
-    def __init__(self, api_url, update_interval: float = 5.0, max_price_age: float = 60.0):
-        if max_price_age < update_interval:
+    def __init__(self, api_url, update_interval: float = 5.0, max_price_age: int = -1):
+        if max_price_age > 0 and max_price_age < update_interval:
             raise ValueError("max_price_age cannot be less than update_interval.")
 
         super().__init__()
@@ -33,9 +33,9 @@ class CustomAPIDataFeed(NetworkBase):
         self._ev_loop = asyncio.get_event_loop()
         self._price: Decimal = Decimal("0")
         self._update_interval: float = update_interval
-        self._max_price_age: float = max_price_age
+        self._max_price_age: int = max_price_age
         self._fetch_price_task: Optional[asyncio.Task] = None
-        self._last_updated_timestamp: float = None
+        self._last_updated_timestamp: int = None
 
     @property
     def name(self):
@@ -75,11 +75,12 @@ class CustomAPIDataFeed(NetworkBase):
         return NetworkStatus.CONNECTED
 
     def get_price(self) -> Decimal:
-        if self._last_updated_timestamp is not None:
-            age = time.time() - self._last_updated_timestamp
+        if self._max_price_age > 0 and self._last_updated_timestamp is not None:
+            age = int(time.time()) - self._last_updated_timestamp
             if age > self._max_price_age:
                 # price is too old to be considered valid
                 return Decimal("nan")
+
         return self._price
 
     async def fetch_price_loop(self):
@@ -102,7 +103,7 @@ class CustomAPIDataFeed(NetworkBase):
             if resp.status != 200:
                 raise Exception(f"Custom API Feed {self.name} server error: {resp_text}")
             self._price = Decimal(str(resp_text))
-            self._last_updated_timestamp = time.time()
+            self._last_updated_timestamp = int(time.time())
         self._ready_event.set()
 
     async def start_network(self):

--- a/hummingbot/strategy/api_asset_price_delegate.pyx
+++ b/hummingbot/strategy/api_asset_price_delegate.pyx
@@ -2,10 +2,12 @@ from decimal import Decimal
 
 from hummingbot.core.data_type.common import PriceType
 from hummingbot.data_feed.custom_api_data_feed import CustomAPIDataFeed, NetworkStatus
+
 from .asset_price_delegate cimport AssetPriceDelegate
 
+
 cdef class APIAssetPriceDelegate(AssetPriceDelegate):
-    def __init__(self, market: ExchangeBase, api_url: str, update_interval: float = 5.0, max_price_age: float = 60.0):
+    def __init__(self, market: ExchangeBase, api_url: str, update_interval: float = 5.0, max_price_age: int = -1):
         super().__init__()
         self._market = market
         self._custom_api_feed = CustomAPIDataFeed(api_url=api_url, update_interval=update_interval, max_price_age=max_price_age)

--- a/hummingbot/strategy/api_asset_price_delegate.pyx
+++ b/hummingbot/strategy/api_asset_price_delegate.pyx
@@ -5,10 +5,10 @@ from hummingbot.data_feed.custom_api_data_feed import CustomAPIDataFeed, Network
 from .asset_price_delegate cimport AssetPriceDelegate
 
 cdef class APIAssetPriceDelegate(AssetPriceDelegate):
-    def __init__(self, market: ExchangeBase, api_url: str, update_interval: float = 5.0):
+    def __init__(self, market: ExchangeBase, api_url: str, update_interval: float = 5.0, max_price_age: float = 60.0):
         super().__init__()
         self._market = market
-        self._custom_api_feed = CustomAPIDataFeed(api_url=api_url, update_interval=update_interval)
+        self._custom_api_feed = CustomAPIDataFeed(api_url=api_url, update_interval=update_interval, max_price_age=max_price_age)
         self._custom_api_feed.start()
 
     def get_price_by_type(self, _: PriceType) -> Decimal:

--- a/hummingbot/strategy/pure_market_making/pure_market_making.pxd
+++ b/hummingbot/strategy/pure_market_making/pure_market_making.pxd
@@ -74,6 +74,7 @@ cdef class PureMarketMakingStrategy(StrategyBase):
     cdef c_apply_order_optimization(self, object proposal)
     cdef c_apply_add_transaction_costs(self, object proposal)
     cdef bint c_is_within_tolerance(self, list current_prices, list proposal_prices)
+    cdef c_cancel_all_active_orders(self)
     cdef c_cancel_active_orders(self, object proposal)
     cdef c_cancel_orders_below_min_spread(self)
     cdef c_cancel_active_orders_on_max_age_limit(self)

--- a/hummingbot/strategy/pure_market_making/pure_market_making.pyx
+++ b/hummingbot/strategy/pure_market_making/pure_market_making.pyx
@@ -747,8 +747,8 @@ cdef class PureMarketMakingStrategy(StrategyBase):
                                           f"making may be dangerous when markets or networks are unstable.")
 
             proposal = None
-            ref_price_available = not self.get_price().is_nan()
-            if not ref_price_available:
+            ref_price_unavailable = self.get_price().is_nan()
+            if ref_price_unavailable:
                 self.logger().info("Reference price not available. Waiting for a new price to resume strategy...")
 
                 if len(self.active_orders) > 0:

--- a/hummingbot/strategy/pure_market_making/pure_market_making.pyx
+++ b/hummingbot/strategy/pure_market_making/pure_market_making.pyx
@@ -7,27 +7,37 @@ import numpy as np
 import pandas as pd
 
 from hummingbot.connector.exchange_base import ExchangeBase
+
 from hummingbot.connector.exchange_base cimport ExchangeBase
 from hummingbot.core.clock cimport Clock
+
 from hummingbot.core.data_type.common import OrderType, PriceType, TradeType
+
 from hummingbot.core.data_type.limit_order cimport LimitOrder
+
 from hummingbot.core.data_type.limit_order import LimitOrder
 from hummingbot.core.network_iterator import NetworkStatus
 from hummingbot.core.utils import map_df_to_str
+
 from hummingbot.strategy.asset_price_delegate cimport AssetPriceDelegate
+
 from hummingbot.strategy.asset_price_delegate import AssetPriceDelegate
 from hummingbot.strategy.hanging_orders_tracker import CreatedPairOfOrders, HangingOrdersTracker
 from hummingbot.strategy.market_trading_pair_tuple import MarketTradingPairTuple
+
 from hummingbot.strategy.order_book_asset_price_delegate cimport OrderBookAssetPriceDelegate
+
 from hummingbot.strategy.strategy_base import StrategyBase
 from hummingbot.strategy.utils import order_age
+
 from .data_types import PriceSize, Proposal
 from .inventory_cost_price_delegate import InventoryCostPriceDelegate
-from .inventory_skew_calculator cimport c_calculate_bid_ask_ratios_from_base_asset_ratio
-from .inventory_skew_calculator import calculate_total_order_size
-from .pure_market_making_order_tracker import PureMarketMakingOrderTracker
-from .moving_price_band import MovingPriceBand
 
+from .inventory_skew_calculator cimport c_calculate_bid_ask_ratios_from_base_asset_ratio
+
+from .inventory_skew_calculator import calculate_total_order_size
+from .moving_price_band import MovingPriceBand
+from .pure_market_making_order_tracker import PureMarketMakingOrderTracker
 
 NaN = float("nan")
 s_decimal_zero = Decimal(0)
@@ -742,7 +752,7 @@ cdef class PureMarketMakingStrategy(StrategyBase):
                 self.logger().info("Reference price not available. Waiting for a new price to resume strategy...")
 
                 if len(self.active_orders) > 0:
-                    self.logger().info("Cancelling all active orders for safety...")
+                    self.logger().info("Cancelling any active orders for safety...")
                     self.c_cancel_all_active_orders()
 
                 return

--- a/hummingbot/strategy/pure_market_making/pure_market_making_config_map.py
+++ b/hummingbot/strategy/pure_market_making/pure_market_making_config_map.py
@@ -391,8 +391,9 @@ pure_market_making_config_map = {
                   validator=lambda v: validate_decimal(v, Decimal("0.5"))),
     "custom_api_max_price_age":
         ConfigVar(key="custom_api_max_price_age",
-                  prompt="Enter a time in seconds to invalidate the price from custom API if stale "
-                         "(Enter -1 to deactivate this feature) >>> ",
+                  prompt="Enter the number of seconds after which a price from the custom API becomes stale"
+                                 "(default: -1, prices never expire) >>>",
+
                   required_if=lambda: False,
                   default=int(-1),
                   type_str="int",

--- a/hummingbot/strategy/pure_market_making/pure_market_making_config_map.py
+++ b/hummingbot/strategy/pure_market_making/pure_market_making_config_map.py
@@ -379,6 +379,13 @@ pure_market_making_config_map = {
                   default=float(5),
                   type_str="float",
                   validator=lambda v: validate_decimal(v, Decimal("0.5"))),
+    "custom_api_max_price_age":
+        ConfigVar(key="custom_api_max_price_age",
+                  prompt="Enter custom API max price age in seconds (default: 60.0, min: 5.0) >>> ",
+                  required_if=lambda: False,
+                  default=float(60),
+                  type_str="float",
+                  validator=lambda v: validate_decimal(v, Decimal("5.0"))),
     "order_override":
         ConfigVar(key="order_override",
                   prompt=None,

--- a/hummingbot/strategy/pure_market_making/pure_market_making_config_map.py
+++ b/hummingbot/strategy/pure_market_making/pure_market_making_config_map.py
@@ -79,6 +79,16 @@ def validate_price_floor_ceiling(value: str) -> Optional[str]:
         return "Value must be more than 0 or -1 to disable this feature."
 
 
+def validate_custom_api_max_price_age(value: int) -> Optional[str]:
+    try:
+        value = int(value)
+    except Exception:
+        return f"{value} is not in integer format."
+
+    if value != -1:
+        return validate_int(value, min_value=1)
+
+
 def validate_price_type(value: str) -> Optional[str]:
     error = None
     price_source = pure_market_making_config_map.get("price_source").value
@@ -386,7 +396,7 @@ pure_market_making_config_map = {
                   required_if=lambda: False,
                   default=int(-1),
                   type_str="int",
-                  validator=lambda v: None if v == -1 else validate_int(v, 1)),
+                  validator=lambda v: validate_custom_api_max_price_age(v)),
     "order_override":
         ConfigVar(key="order_override",
                   prompt=None,

--- a/hummingbot/strategy/pure_market_making/pure_market_making_config_map.py
+++ b/hummingbot/strategy/pure_market_making/pure_market_making_config_map.py
@@ -82,8 +82,12 @@ def validate_price_floor_ceiling(value: str) -> Optional[str]:
 def validate_custom_api_max_price_age(value: int) -> Optional[str]:
     try:
         value = int(value)
+        update_interval = float(pure_market_making_config_map.get("custom_api_update_interval").value)
     except Exception:
         return f"{value} is not in integer format."
+
+    if update_interval < value:
+        return f"Max price age must be >= than custom_api_update_interval ({update_interval})"
 
     if value != -1:
         return validate_int(value, min_value=1)
@@ -392,7 +396,7 @@ pure_market_making_config_map = {
     "custom_api_max_price_age":
         ConfigVar(key="custom_api_max_price_age",
                   prompt="Enter the number of seconds after which a price from the custom API becomes stale"
-                                 "(default: -1, prices never expire) >>>",
+                         "(default: -1, prices never expire) >>>",
 
                   required_if=lambda: False,
                   default=int(-1),

--- a/hummingbot/strategy/pure_market_making/pure_market_making_config_map.py
+++ b/hummingbot/strategy/pure_market_making/pure_market_making_config_map.py
@@ -381,11 +381,12 @@ pure_market_making_config_map = {
                   validator=lambda v: validate_decimal(v, Decimal("0.5"))),
     "custom_api_max_price_age":
         ConfigVar(key="custom_api_max_price_age",
-                  prompt="Enter custom API max price age in seconds (default: 60.0, min: 5.0) >>> ",
+                  prompt="Enter a time in seconds to invalidate the price from custom API if stale "
+                         "(Enter -1 to deactivate this feature) >>> ",
                   required_if=lambda: False,
-                  default=float(60),
-                  type_str="float",
-                  validator=lambda v: validate_decimal(v, Decimal("5.0"))),
+                  default=int(-1),
+                  type_str="int",
+                  validator=lambda v: validate_int(v, 1)),
     "order_override":
         ConfigVar(key="order_override",
                   prompt=None,

--- a/hummingbot/strategy/pure_market_making/pure_market_making_config_map.py
+++ b/hummingbot/strategy/pure_market_making/pure_market_making_config_map.py
@@ -386,7 +386,7 @@ pure_market_making_config_map = {
                   required_if=lambda: False,
                   default=int(-1),
                   type_str="int",
-                  validator=lambda v: validate_int(v, 1)),
+                  validator=lambda v: v == -1 or validate_int(v, 1)),
     "order_override":
         ConfigVar(key="order_override",
                   prompt=None,

--- a/hummingbot/strategy/pure_market_making/pure_market_making_config_map.py
+++ b/hummingbot/strategy/pure_market_making/pure_market_making_config_map.py
@@ -386,7 +386,7 @@ pure_market_making_config_map = {
                   required_if=lambda: False,
                   default=int(-1),
                   type_str="int",
-                  validator=lambda v: v == -1 or validate_int(v, 1)),
+                  validator=lambda v: True if v == -1 else validate_int(v, 1)),
     "order_override":
         ConfigVar(key="order_override",
                   prompt=None,

--- a/hummingbot/strategy/pure_market_making/pure_market_making_config_map.py
+++ b/hummingbot/strategy/pure_market_making/pure_market_making_config_map.py
@@ -386,7 +386,7 @@ pure_market_making_config_map = {
                   required_if=lambda: False,
                   default=int(-1),
                   type_str="int",
-                  validator=lambda v: True if v == -1 else validate_int(v, 1)),
+                  validator=lambda v: None if v == -1 else validate_int(v, 1)),
     "order_override":
         ConfigVar(key="order_override",
                   prompt=None,

--- a/hummingbot/strategy/pure_market_making/start.py
+++ b/hummingbot/strategy/pure_market_making/start.py
@@ -52,6 +52,7 @@ def start(self):
         price_source_market = c_map.get("price_source_market").value
         price_source_custom_api = c_map.get("price_source_custom_api").value
         custom_api_update_interval = c_map.get("custom_api_update_interval").value
+        custom_api_max_price_age = c_map.get("custom_api_max_price_age").value
         order_refresh_tolerance_pct = c_map.get("order_refresh_tolerance_pct").value / Decimal('100')
         order_override = c_map.get("order_override").value
         split_order_levels_enabled = c_map.get("split_order_levels_enabled").value
@@ -91,7 +92,7 @@ def start(self):
             asset_price_delegate = OrderBookAssetPriceDelegate(ext_market, asset_trading_pair)
         elif price_source == "custom_api":
             asset_price_delegate = APIAssetPriceDelegate(self.markets[exchange], price_source_custom_api,
-                                                         custom_api_update_interval)
+                                                         custom_api_update_interval, custom_api_max_price_age)
         inventory_cost_price_delegate = None
         if price_type == "inventory_cost":
             db = HummingbotApplication.main_application().trade_fill_db

--- a/hummingbot/templates/conf_pure_market_making_strategy_TEMPLATE.yml
+++ b/hummingbot/templates/conf_pure_market_making_strategy_TEMPLATE.yml
@@ -124,7 +124,7 @@ price_source_custom_api: null
 # An interval time in second to update the price from custom api (for custom_api pricing source).
 custom_api_update_interval: null
 
-# A maximum age in seconds before invalidating the price from custom api (for custom_api pricing source).
+# A time age in seconds before invalidating the price from custom api if stale (for custom_api pricing source).
 custom_api_max_price_age: null
 
 #Take order if they cross order book when external price source is enabled

--- a/hummingbot/templates/conf_pure_market_making_strategy_TEMPLATE.yml
+++ b/hummingbot/templates/conf_pure_market_making_strategy_TEMPLATE.yml
@@ -124,6 +124,9 @@ price_source_custom_api: null
 # An interval time in second to update the price from custom api (for custom_api pricing source).
 custom_api_update_interval: null
 
+# A maximum age in seconds before invalidating the price from custom api (for custom_api pricing source).
+custom_api_max_price_age: null
+
 #Take order if they cross order book when external price source is enabled
 take_if_crossed: null
 

--- a/test/hummingbot/data_feed/test_custom_api_data_feed.py
+++ b/test/hummingbot/data_feed/test_custom_api_data_feed.py
@@ -1,6 +1,6 @@
 import asyncio
-import decimal
 import unittest
+from decimal import Decimal, InvalidOperation
 
 from aioresponses import aioresponses
 
@@ -15,17 +15,17 @@ class TestCustomApiDataFeed(unittest.TestCase):
         self.assertEqual(feed.name, 'custom_api')
         self.assertEqual(feed.api_url, 'fakeUrl')
         self.assertEqual(feed.update_interval, 5.0)
-        self.assertEqual(feed.max_price_age, 60.0)
+        self.assertEqual(feed.max_price_age, -1)
         self.assertEqual(feed.health_check_endpoint, 'fakeUrl')
 
     def test_init_throws_when_max_price_age_less_than_update_interval(self):
         with self.assertRaises(ValueError):
-            CustomAPIDataFeed('fakeUrl', 60.0, 5.0)
+            CustomAPIDataFeed('fakeUrl', 60.0, 50)
 
     def test_init_with_custom_params(self):
-        feed = CustomAPIDataFeed('fakeUrl', 10.0, 30.0)
+        feed = CustomAPIDataFeed('fakeUrl', 10.0, 30)
         self.assertEqual(feed.update_interval, 10.0)
-        self.assertEqual(feed.max_price_age, 30.0)
+        self.assertEqual(feed.max_price_age, 30)
 
     @aioresponses()
     @unittest.mock.patch('time.time')
@@ -38,41 +38,61 @@ class TestCustomApiDataFeed(unittest.TestCase):
         feed = CustomAPIDataFeed('fakeUrl')
         asyncio.get_event_loop().run_until_complete(feed.fetch_price())
 
-        self.assertEqual(feed.get_price(), decimal.Decimal(str(mock_price)))
+        self.assertEqual(feed.get_price(), Decimal(str(mock_price)))
         self.assertEqual(feed.last_updated_timestamp, mock_timestamp)
 
     @aioresponses()
     def test_price_is_not_updated_when_api_response_is_invalid(self, mock_api):
-        mock_price = '1.0'
-        mock_api.get(url='fakeUrl', body=mock_price)
+        initial_price = '1.0'
+        mock_api.get(url='fakeUrl', body=initial_price)
         feed = CustomAPIDataFeed('fakeUrl')
 
         asyncio.get_event_loop().run_until_complete(feed.fetch_price())
-        self.assertEqual(feed.get_price(), decimal.Decimal(mock_price))
+        self.assertEqual(feed.get_price(), Decimal(initial_price))
 
         with self.assertRaises(Exception):
             mock_api.get(url='fakeUrl', status=500, body="10.0")
             asyncio.get_event_loop().run_until_complete(feed.fetch_price())
 
-        self.assertEqual(feed.get_price(), decimal.Decimal(mock_price))
+        self.assertEqual(feed.get_price(), Decimal(initial_price))
 
-        with self.assertRaises(decimal.InvalidOperation):
+        with self.assertRaises(InvalidOperation):
             mock_api.get(url='fakeUrl', status=200, body="invalid_price")
             asyncio.get_event_loop().run_until_complete(feed.fetch_price())
 
+        self.assertEqual(feed.get_price(), Decimal(initial_price))
+
     @aioresponses()
     @unittest.mock.patch('time.time')
-    def test_price_is_nan_when_last_updated_exceeds_max_age(self, mock_api, mock_time):
+    def test_price_is_invalidated_when_last_updated_exceeds_max_age(self, mock_api, mock_time):
         mock_timestamp = 1231006505
         mock_price = 1.09213849
         mock_time.return_value = mock_timestamp
         mock_api.get(url='fakeUrl', body=str(mock_price))
 
-        feed = CustomAPIDataFeed('fakeUrl')
+        feed = CustomAPIDataFeed('fakeUrl', max_price_age=10)
         asyncio.get_event_loop().run_until_complete(feed.fetch_price())
 
-        self.assertEqual(feed.get_price(), decimal.Decimal(str(mock_price)))
+        self.assertEqual(feed.get_price(), Decimal(str(mock_price)))
         self.assertEqual(feed.last_updated_timestamp, mock_timestamp)
 
         mock_time.return_value = mock_timestamp + feed.max_price_age + 1
         self.assertTrue(feed.get_price().is_nan())
+
+    @aioresponses()
+    @unittest.mock.patch('time.time')
+    def test_price_is_not_invalidated_when_max_age_is_disabled(self, mock_api, mock_time):
+        mock_timestamp = 1231006505
+        initial_price = 1.09213849
+        mock_time.return_value = mock_timestamp
+        mock_api.get(url='fakeUrl', body=str(initial_price))
+
+        feed = CustomAPIDataFeed('fakeUrl')
+        asyncio.get_event_loop().run_until_complete(feed.fetch_price())
+
+        self.assertEqual(feed.get_price(), Decimal(str(initial_price)))
+        self.assertEqual(feed.last_updated_timestamp, mock_timestamp)
+
+        far_timestamp = mock_timestamp + 1000000
+        mock_time.return_value = far_timestamp
+        self.assertEqual(feed.get_price(), Decimal(str(initial_price)))

--- a/test/hummingbot/data_feed/test_custom_api_data_feed.py
+++ b/test/hummingbot/data_feed/test_custom_api_data_feed.py
@@ -1,0 +1,78 @@
+import asyncio
+import decimal
+import unittest
+
+from aioresponses import aioresponses
+
+from hummingbot.data_feed.custom_api_data_feed import CustomAPIDataFeed
+
+
+class TestCustomApiDataFeed(unittest.TestCase):
+
+    def test_init(self):
+        feed = CustomAPIDataFeed('fakeUrl')
+
+        self.assertEqual(feed.name, 'custom_api')
+        self.assertEqual(feed.api_url, 'fakeUrl')
+        self.assertEqual(feed.update_interval, 5.0)
+        self.assertEqual(feed.max_price_age, 60.0)
+        self.assertEqual(feed.health_check_endpoint, 'fakeUrl')
+
+    def test_init_throws_when_max_price_age_less_than_update_interval(self):
+        with self.assertRaises(ValueError):
+            CustomAPIDataFeed('fakeUrl', 60.0, 5.0)
+
+    def test_init_with_custom_params(self):
+        feed = CustomAPIDataFeed('fakeUrl', 10.0, 30.0)
+        self.assertEqual(feed.update_interval, 10.0)
+        self.assertEqual(feed.max_price_age, 30.0)
+
+    @aioresponses()
+    @unittest.mock.patch('time.time')
+    def test_price_is_updated_when_api_response_is_valid(self, mock_api, mock_time):
+        mock_timestamp = 1231006505
+        mock_price = 1.09213849
+        mock_time.return_value = mock_timestamp
+        mock_api.get(url='fakeUrl', body=str(mock_price))
+
+        feed = CustomAPIDataFeed('fakeUrl')
+        asyncio.get_event_loop().run_until_complete(feed.fetch_price())
+
+        self.assertEqual(feed.get_price(), decimal.Decimal(str(mock_price)))
+        self.assertEqual(feed.last_updated_timestamp, mock_timestamp)
+
+    @aioresponses()
+    def test_price_is_not_updated_when_api_response_is_invalid(self, mock_api):
+        mock_price = '1.0'
+        mock_api.get(url='fakeUrl', body=mock_price)
+        feed = CustomAPIDataFeed('fakeUrl')
+
+        asyncio.get_event_loop().run_until_complete(feed.fetch_price())
+        self.assertEqual(feed.get_price(), decimal.Decimal(mock_price))
+
+        with self.assertRaises(Exception):
+            mock_api.get(url='fakeUrl', status=500, body="10.0")
+            asyncio.get_event_loop().run_until_complete(feed.fetch_price())
+
+        self.assertEqual(feed.get_price(), decimal.Decimal(mock_price))
+
+        with self.assertRaises(decimal.InvalidOperation):
+            mock_api.get(url='fakeUrl', status=200, body="invalid_price")
+            asyncio.get_event_loop().run_until_complete(feed.fetch_price())
+
+    @aioresponses()
+    @unittest.mock.patch('time.time')
+    def test_price_is_nan_when_last_updated_exceeds_max_age(self, mock_api, mock_time):
+        mock_timestamp = 1231006505
+        mock_price = 1.09213849
+        mock_time.return_value = mock_timestamp
+        mock_api.get(url='fakeUrl', body=str(mock_price))
+
+        feed = CustomAPIDataFeed('fakeUrl')
+        asyncio.get_event_loop().run_until_complete(feed.fetch_price())
+
+        self.assertEqual(feed.get_price(), decimal.Decimal(str(mock_price)))
+        self.assertEqual(feed.last_updated_timestamp, mock_timestamp)
+
+        mock_time.return_value = mock_timestamp + feed.max_price_age + 1
+        self.assertTrue(feed.get_price().is_nan())

--- a/test/hummingbot/strategy/pure_market_making/test_pmm.py
+++ b/test/hummingbot/strategy/pure_market_making/test_pmm.py
@@ -1116,6 +1116,20 @@ class PMMUnitTest(unittest.TestCase):
         self.assertEqual(Decimal("102.01"), sell.price)
         self.assertEqual(1, sell.quantity)
 
+    def test_active_orders_are_canceled_when_ref_price_is_nan(self):
+        strategy = self.custom_price_source_strategy
+        self.clock.add_iterator(strategy)
+
+        self.clock.backtest_til(self.start_timestamp + self.clock_tick_size)
+        self.assertEqual(1, len(strategy.active_buys))
+        self.assertEqual(1, len(strategy.active_sells))
+
+        self.custom_asset_price_delegate.set_mock_price(mock_price=Decimal("NaN"))
+
+        self.clock.backtest_til(self.start_timestamp + self.clock_tick_size + 1)
+        self.assertEqual(0, len(strategy.active_buys))
+        self.assertEqual(0, len(strategy.active_sells))
+
     def test_no_new_orders_created_until_previous_orders_cancellation_confirmed(self):
         strategy = self.one_level_strategy
         self.clock.add_iterator(strategy)

--- a/test/hummingbot/strategy/pure_market_making/test_pmm_config_map.py
+++ b/test/hummingbot/strategy/pure_market_making/test_pmm_config_map.py
@@ -129,6 +129,8 @@ class TestPMMConfigMap(unittest.TestCase):
         self.assertEqual(expected, error)
 
     def test_validate_custom_api_max_price_age(self):
+        pmm_config_map["custom_api_update_interval"].value = 30.0
+
         self.assertEqual(
             validate_custom_api_max_price_age(value="0"),
             "Value cannot be less than 1."
@@ -137,5 +139,11 @@ class TestPMMConfigMap(unittest.TestCase):
             validate_custom_api_max_price_age(value="invalidNumber"),
             "invalidNumber is not in integer format."
         )
+        self.assertEqual(
+            validate_custom_api_max_price_age(value="31"),
+            "Max price age must be >= than custom_api_update_interval (30.0)"
+        )
+
         self.assertIsNone(validate_custom_api_max_price_age(value="-1"))
         self.assertIsNone(validate_custom_api_max_price_age(value="10"))
+        self.assertIsNone(validate_custom_api_max_price_age(value="30"))

--- a/test/hummingbot/strategy/pure_market_making/test_pmm_config_map.py
+++ b/test/hummingbot/strategy/pure_market_making/test_pmm_config_map.py
@@ -3,13 +3,14 @@ from copy import deepcopy
 
 from hummingbot.client.settings import AllConnectorSettings
 from hummingbot.strategy.pure_market_making.pure_market_making_config_map import (
-    pure_market_making_config_map as pmm_config_map,
-    on_validate_price_source,
-    validate_price_type,
-    order_amount_prompt,
     maker_trading_pair_prompt,
+    on_validate_price_source,
+    order_amount_prompt,
+    pure_market_making_config_map as pmm_config_map,
+    validate_custom_api_max_price_age,
+    validate_decimal_list,
     validate_price_source_exchange,
-    validate_decimal_list
+    validate_price_type,
 )
 
 
@@ -126,3 +127,15 @@ class TestPMMConfigMap(unittest.TestCase):
         error = validate_decimal_list(value="asd")
         expected = "Please enter valid decimal numbers"
         self.assertEqual(expected, error)
+
+    def test_validate_custom_api_max_price_age(self):
+        self.assertEqual(
+            validate_custom_api_max_price_age(value="0"),
+            "Value cannot be less than 1."
+        )
+        self.assertEqual(
+            validate_custom_api_max_price_age(value="invalidNumber"),
+            "invalidNumber is not in integer format."
+        )
+        self.assertIsNone(validate_custom_api_max_price_age(value="-1"))
+        self.assertIsNone(validate_custom_api_max_price_age(value="10"))


### PR DESCRIPTION
**BEFORE REVIEW**
Please note that this PR is pointing to be merged into master but this is only so that the CI runs on every new commit. We should instead merge this into the [v1.17.0 hotfix branch instead](https://github.com/mento-protocol/hummingbot/tree/v1.17.0-hotfix) (to not diverge master from upstream).

**TL;DR: Do not merge to master!**

--------
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

This PR adds a new `custom_api_max_price_age` which allows users to set a threshold for how old the price returned by a custom api can be before invalidating it. 

Before this change, the `CustomAPIDataFeed` would return a cached version of the price whenever there is any error when trying to fetch the price from the API. This is obviously not safe as the price could be outdated but still being used as the reference price for placing orders by the strategies (for example in the PMM). With the new parameter the price will essentially "expire" after certain time if it's not being updated successfully, and just return `NaN`. At the same time the PMM strategy will check that the price is not `NaN` before running the strategy steps (proposing/modifying orders, etc) and will just cancel any active orders for safety instead.

By default the new parameter will be disabled (-1) for backwards compatibility and to not introduce changes to any of the existing strategies.

**Tests performed by the developer**:

1. Wrote unit tests for the `CustomAPIDataFeed` which didn't exist before
2. Ran this locally using this simple python API that exposes methods for testing the behaviour of the bot in different circumstances:

`GET /price` get the latest price
`GET /set?price=0.5`set the latest price to 0.5
`GET /off` switch off /price for it to return 500 with a `NaN` response (to simulate failures)
`GET /on` switch on the /price endpoint to start returning 200 responses again and the price value

```python
from flask import Flask, request

app = Flask(__name__)

PRICE = 1.0
PRICE_STATE = True

@app.route('/price', methods=['GET'])
def get_price():
    if PRICE_STATE:
        return str(PRICE), 200
    else:
        return "NaN", 500

@app.route('/set', methods=['GET'])
def set_price():
    global PRICE
    PRICE = float(request.args.get('price', '1.0'))
    return "Price set", 200

@app.route('/off', methods=['GET'])
def off_price():
    global PRICE_STATE
    PRICE_STATE = False
    return "Switched off", 200

@app.route('/on', methods=['GET'])
def on_price():
    global PRICE_STATE
    PRICE_STATE = True
    return "Switched on", 200


if __name__ == '__main__':
    app.run(debug=True)
```

**Tips for QA testing**:

Run the PMM strategy pointing to the local API and try different scenarios like modifying the set price and flipping the endpoint on and off.
